### PR TITLE
Hotfix 1.9.2

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -45,6 +45,13 @@ jobs:
         java-version: 1.8
         settings-path: ${{ github.workspace }}
 
+    - name: Load local Maven repository cache
+      uses: actions/cache@v2
+      with:
+        path: ~/.m2/repository
+        key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+        restore-keys: |
+          ${{ runner.os }}-maven-
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.9.2 (2021-12-15)
+* Fix CVE-2021-45046
+* Increase log4j-version `2.15.0` -> `2.16.0`
+
 ## 1.9.1 (2021-12-13)
 * Fix CVE-2021-44228
 * Fix [Denial of Service Vulnerability](https://vaadin.com/security/2021-10-27)

--- a/pom.xml
+++ b/pom.xml
@@ -9,14 +9,14 @@
 		<version>3.1.4</version>
 	</parent>
 	<artifactId>user-db-portlet</artifactId>
-	<version>1.9.1</version>
+	<version>1.9.2</version>
 	<name>User Database Portlet</name>
 	<url>http://github.com/qbicsoftware/user-db-portlet</url>
 	<packaging>war</packaging>
 	<properties>
 		<vaadin.version>7.7.28</vaadin.version>
 		<vaadin.plugin.version>7.7.28</vaadin.plugin.version>
-		<log4j.version>2.15.0</log4j.version>
+		<log4j.version>2.16.0</log4j.version>
 	</properties>
 	<!-- we only need to tell maven where to find our parent pom and other QBiC
 		dependencies -->


### PR DESCRIPTION
## 1.9.2 (2021-12-15)
* Fix CVE-2021-45046
* Increase log4j-version `2.15.0` -> `2.16.0`