### PR TITLE
use db id of person to fix mapping for two persons of same name

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 		<version>3.1.4</version>
 	</parent>
 	<artifactId>user-db-portlet</artifactId>
-	<version>2.0.0</version>
+	<version>2.0.1</version>
 	<name>User Database Portlet</name>
 	<url>http://github.com/qbicsoftware/user-db-portlet</url>
 	<packaging>war</packaging>

--- a/src/main/java/life/qbic/portal/portlet/UserDBPortletUI.java
+++ b/src/main/java/life/qbic/portal/portlet/UserDBPortletUI.java
@@ -28,8 +28,6 @@ import java.util.Objects;
 import java.util.Set;
 import life.qbic.datamodel.persons.Affiliation;
 import life.qbic.datamodel.persons.CollaboratorWithResponsibility;
-import life.qbic.datamodel.persons.Person;
-import life.qbic.datamodel.projects.ProjectInfo;
 import life.qbic.openbis.openbisclient.IOpenBisClient;
 import life.qbic.openbis.openbisclient.OpenBisClient;
 import life.qbic.portal.Styles;
@@ -39,6 +37,8 @@ import life.qbic.portal.utils.ConfigurationManagerFactory;
 import life.qbic.portal.utils.PortalUtils;
 import life.qbic.userdb.Config;
 import life.qbic.userdb.DBManager;
+import life.qbic.userdb.model.Person;
+import life.qbic.userdb.model.ProjectInfo;
 import life.qbic.userdb.views.AffiliationInput;
 import life.qbic.userdb.views.AffiliationVIPTab;
 import life.qbic.userdb.views.MultiAffiliationTab;
@@ -62,7 +62,7 @@ public class UserDBPortletUI extends QBiCPortletUI {
   private static final Logger logger = LogManager.getLogger(UserDBPortletUI.class);
   private DBManager dbControl;
   private Map<String, Integer> affiMap;
-  private Map<String, Integer> personMap;
+  private Map<String, Person> personMap;
   private Map<String, ProjectInfo> projectMap;
 
   private TabSheet options;
@@ -72,7 +72,7 @@ public class UserDBPortletUI extends QBiCPortletUI {
   public static String tmpFolder;
 
   private IOpenBisClient openbis;
-  private final boolean development = false;
+  private final boolean development = true;
 
   @Override
   protected Layout getPortletContent(final VaadinRequest request) {
@@ -151,47 +151,6 @@ public class UserDBPortletUI extends QBiCPortletUI {
     } else {
       personMap = dbControl.getPersonMap();
 
-      /*
-       * Removed since 1.8.0 as most of the functionality moved to offer-manager-portlet 2
-       * 
-       * 
-       * affiMap = dbControl.getAffiliationMap();
-       * 
-       * Map<String, Integer> colNamesToMaxLength = fillMaxInputLengthMap();
-       * 
-       * Set<String> instituteNames = dbControl.getInstituteNames(); List<String> facultyEnums =
-       * dbControl.getPossibleEnumsForColumnsInTable("organizations", "faculty"); List<String>
-       * affiliationRoles = dbControl.getPossibleEnumsForColumnsInTable("persons_organizations",
-       * "occupation"); List<String> titleEnums =
-       * dbControl.getPossibleEnumsForColumnsInTable("persons", "title");
-       * 
-       * PersonInput addUserTab = new PersonInput(titleEnums, affiMap, affiliationRoles,
-       * colNamesToMaxLength, new AffiliationInput(instituteNames, facultyEnums, personMap,
-       * colNamesToMaxLength)); options.addTab(addUserTab, "New Person");
-       * 
-       * AffiliationInput addAffilTab = new AffiliationInput(instituteNames, facultyEnums,
-       * personMap, colNamesToMaxLength); options.addTab(addAffilTab, "New Affiliation");
-       * 
-       * SearchView searchView = new SearchView(); options.addTab(searchView, "Search Entries");
-       * 
-       * List<Affiliation> affiTable = dbControl.getAffiliationTable(); Map<Integer, Pair<String,
-       * String>> affiPeople = new HashMap<Integer, Pair<String, String>>(); for (Affiliation a :
-       * affiTable) { int id = a.getID(); affiPeople.put(id, new ImmutablePair<String,
-       * String>(a.getContactPerson(), a.getHeadName())); } PersonBatchUpload batchTab = new
-       * PersonBatchUpload(titleEnums, affiliationRoles, affiMap); options.addTab(batchTab,
-       * "Upload Person Table");
-       * 
-       * AffiliationVIPTab vipTab = new AffiliationVIPTab(personMap, affiMap, affiPeople);
-       * options.addTab(vipTab, "Edit Affiliation VIPs");
-       * 
-       * MultiAffiliationTab multiAffilTab = new MultiAffiliationTab(personMap, affiMap,
-       * affiliationRoles); options.addTab(multiAffilTab, "Additional Person-Affiliations");
-       * 
-       * if (!admin) { options.getTab(multiAffilTab).setEnabled(false);
-       * options.getTab(vipTab).setEnabled(false);
-       * 
-       * options.getTab(3).setEnabled(false); options.getTab(4).setEnabled(false); }
-       */
       String userID = "";
       if (PortalUtils.isLiferayPortlet()) {
         logger.info("DB Tools running on Liferay, fetching user ID.");
@@ -202,9 +161,9 @@ public class UserDBPortletUI extends QBiCPortletUI {
           userID = "admin";
         }
       }
-      Map<String, ProjectInfo> userProjects = new HashMap<String, ProjectInfo>();
+      Map<String, ProjectInfo> userProjects = new HashMap<>();
 
-      List<Project> openbisProjectsForUser = new ArrayList<Project>();
+      List<Project> openbisProjectsForUser = new ArrayList<>();
       Set<String> spaces = new HashSet<>(openbis.getUserSpaces(userID));
 
       List<Project> allOpenbisProjects = openbis.listProjects();
@@ -285,22 +244,14 @@ public class UserDBPortletUI extends QBiCPortletUI {
             }
             projectView.setCollaboratorsOfProject(collaborators);
 
-            Person investigator = getPersonOrNull(projectMap.get(item).getInvestigator());
-            Person manager = getPersonOrNull(projectMap.get(item).getManager());
-            Person contact = getPersonOrNull(projectMap.get(item).getContact());
+            ProjectInfo info = projectMap.get(item);
 
-            projectView.handleProjectValueChange(item, investigator, contact, manager);
+            projectView.handleProjectValueChange(item, info.getInvestigator(), info.getContact(), info.getManager());
           } else {
             projectView.handleProjectDeselect();
           }
         }
 
-        private Person getPersonOrNull(String name) {
-          if (personMap.get(name) != null) {
-            return dbControl.getPersonWithAffiliations(personMap.get(name)).get(0);
-          }
-          return null;
-        }
       });
 
       projectView.getInfoCommitButton().addClickListener(new ClickListener() {
@@ -316,18 +267,18 @@ public class UserDBPortletUI extends QBiCPortletUI {
                   info.getSecondaryName());
             else
               dbControl.addOrChangeSecondaryNameForProject(id, info.getSecondaryName());
-            if (info.getInvestigator() == null || info.getInvestigator().isEmpty())
+            if (info.getInvestigator() == null)
               dbControl.removePersonFromProject(id, "PI");
             else
-              dbControl.addOrUpdatePersonToProject(id, personMap.get(info.getInvestigator()), "PI");
-            if (info.getContact() == null || info.getContact().isEmpty())
+              dbControl.addOrUpdatePersonToProject(id, personMap.get(info.getInvestigator()).getId(), "PI");
+            if (info.getContact() == null)
               dbControl.removePersonFromProject(id, "Contact");
             else
-              dbControl.addOrUpdatePersonToProject(id, personMap.get(info.getContact()), "Contact");
-            if (info.getManager() == null || info.getManager().isEmpty())
+              dbControl.addOrUpdatePersonToProject(id, personMap.get(info.getContact()).getId(), "Contact");
+            if (info.getManager() == null)
               dbControl.removePersonFromProject(id, "Manager");
             else
-              dbControl.addOrUpdatePersonToProject(id, personMap.get(info.getManager()), "Manager");
+              dbControl.addOrUpdatePersonToProject(id, personMap.get(info.getManager()).getId(), "Manager");
             projectView.updateChangedInfo(info);
           }
         }
@@ -344,7 +295,7 @@ public class UserDBPortletUI extends QBiCPortletUI {
             String name = c.getPerson();
             int personID = -1;
             if (personMap.get(name) != null)
-              personID = personMap.get(name);
+              personID = personMap.get(name).getId();
             if (personID < 1)
               dbControl.removePersonFromExperiment(experimentID);
             else
@@ -453,18 +404,18 @@ public class UserDBPortletUI extends QBiCPortletUI {
         if (affi != null && !affi.isEmpty()) {
           search.setAffiliations(dbControl.getAffiliationsContaining(affi));
         } else
-          search.setAffiliations(new ArrayList<Affiliation>());
+          search.setAffiliations(new ArrayList<>());
       }
     });
 
     search.getSearchPersonButton().addClickListener(new Button.ClickListener() {
       @Override
       public void buttonClick(ClickEvent event) {
-        String person = search.getPersonSearchField().getValue();
-        if (person != null && !person.isEmpty()) {
-          search.setPersons(dbControl.getPersonsContaining(person));
+        String personName = search.getPersonSearchField().getValue();
+        if (personName != null && !personName.isEmpty()) {
+          search.setPersons(dbControl.getPersonsContaining(personName));
         } else
-          search.setPersons(new ArrayList<Person>());
+          search.setPersons(new ArrayList<>());
       }
     });
 
@@ -550,7 +501,7 @@ public class UserDBPortletUI extends QBiCPortletUI {
       public void buttonClick(ClickEvent event) {
         if (multiAffilTab.isValid()) {
           if (dbControl.addOrUpdatePersonAffiliationConnections(
-              personMap.get(multiAffilTab.getPersonBox().getValue()),
+              personMap.get(multiAffilTab.getPersonBox().getValue()).getId(),
               multiAffilTab.getChangedAndNewConnections()))
             successfulCommit();
           else
@@ -565,12 +516,12 @@ public class UserDBPortletUI extends QBiCPortletUI {
       @Override
       public void buttonClick(ClickEvent event) {
         String personName = multiAffilTab.getPersonBox().getValue().toString();
-        Person p = dbControl.getPerson(personMap.get(personName));
+        Person p = personMap.get(personName);
 
         String affiName = multiAffilTab.getOrganizationBox().getValue().toString();
         Person newP = new Person(p.getUsername(), p.getTitle(), p.getFirstName(), p.getLastName(),
             p.getEmail(), p.getPhone(), affiMap.get(affiName), affiName, "");
-        multiAffilTab.addDataToTable(new ArrayList<Person>(Arrays.asList(newP)));
+        multiAffilTab.addDataToTable(new ArrayList<>(Arrays.asList(newP)));
         multiAffilTab.getAddButton().setEnabled(false);
       }
     });
@@ -582,7 +533,7 @@ public class UserDBPortletUI extends QBiCPortletUI {
         if (multiAffilTab.getPersonBox().getValue() != null) {
           String personName = multiAffilTab.getPersonBox().getValue().toString();
           multiAffilTab.reactToPersonSelection(personName,
-              dbControl.getPersonWithAffiliations(personMap.get(personName)));
+              dbControl.getPersonWithAffiliations(personMap.get(personName).getId()));
           multiAffilTab.getAddButton().setEnabled(multiAffilTab.newAffiliationPossible());
         }
       }

--- a/src/main/java/life/qbic/portal/portlet/UserDBPortletUI.java
+++ b/src/main/java/life/qbic/portal/portlet/UserDBPortletUI.java
@@ -38,6 +38,7 @@ import life.qbic.portal.utils.PortalUtils;
 import life.qbic.userdb.Config;
 import life.qbic.userdb.DBManager;
 import life.qbic.userdb.model.Person;
+import life.qbic.userdb.model.Person.PersonBuilder;
 import life.qbic.userdb.model.ProjectInfo;
 import life.qbic.userdb.views.AffiliationInput;
 import life.qbic.userdb.views.AffiliationVIPTab;
@@ -517,9 +518,13 @@ public class UserDBPortletUI extends QBiCPortletUI {
         Person p = personMap.get(personName);
 
         String affiName = multiAffilTab.getOrganizationBox().getValue().toString();
-        Person newP = new Person(p.getUsername(), p.getTitle(), p.getFirstName(), p.getLastName(),
-            p.getEmail(), p.getPhone(), affiMap.get(affiName), affiName, "");
-        multiAffilTab.addDataToTable(new ArrayList<>(Arrays.asList(newP)));
+        PersonBuilder personBuilder = new PersonBuilder();
+        personBuilder.createPerson(p.getTitle(), p.getFirstName(), p.getLastName(),
+            p.getEmail())
+            .withUsername(p.getUsername())
+            .withPhoneNumber(p.getPhone())
+            .withRoleAtAffiliation(affiMap.get(affiName), affiName, "");
+        multiAffilTab.addDataToTable(new ArrayList<>(Arrays.asList(personBuilder.getPerson())));
         multiAffilTab.getAddButton().setEnabled(false);
       }
     });

--- a/src/main/java/life/qbic/portal/portlet/UserDBPortletUI.java
+++ b/src/main/java/life/qbic/portal/portlet/UserDBPortletUI.java
@@ -82,7 +82,6 @@ public class UserDBPortletUI extends QBiCPortletUI {
 
     String userID = "";
     boolean success = true;
-    System.err.println(QBiCPortletUI.DEVELOPER_PROPERTIES_FILE_PATH);
     ConfigurationManager manager = ConfigurationManagerFactory.getInstance();
     tmpFolder = manager.getTmpFolder();
     if (PortalUtils.isLiferayPortlet()) {

--- a/src/main/java/life/qbic/portal/portlet/UserDBPortletUI.java
+++ b/src/main/java/life/qbic/portal/portlet/UserDBPortletUI.java
@@ -55,7 +55,6 @@ import org.apache.logging.log4j.Logger;
  * found in the {@code portal-utils-lib} library.
  */
 @Theme("mytheme")
-@SuppressWarnings("serial")
 @Widgetset("life.qbic.portlet.AppWidgetSet")
 public class UserDBPortletUI extends QBiCPortletUI {
 
@@ -67,12 +66,11 @@ public class UserDBPortletUI extends QBiCPortletUI {
 
   private TabSheet options;
 
-  private ConfigurationManager manager;
   private Config config;
   public static String tmpFolder;
 
   private IOpenBisClient openbis;
-  private final boolean development = true;
+  private final boolean development = false;
 
   @Override
   protected Layout getPortletContent(final VaadinRequest request) {
@@ -84,7 +82,8 @@ public class UserDBPortletUI extends QBiCPortletUI {
 
     String userID = "";
     boolean success = true;
-    manager = ConfigurationManagerFactory.getInstance();
+    System.err.println(QBiCPortletUI.DEVELOPER_PROPERTIES_FILE_PATH);
+    ConfigurationManager manager = ConfigurationManagerFactory.getInstance();
     tmpFolder = manager.getTmpFolder();
     if (PortalUtils.isLiferayPortlet()) {
       // read in the configuration file
@@ -202,7 +201,7 @@ public class UserDBPortletUI extends QBiCPortletUI {
       // searchView, projectView);
       projectView.getProjectTable().addValueChangeListener(new ValueChangeListener() {
 
-        private Map<String, String> expTypeCodeTranslation = new HashMap<String, String>() {
+        private final Map<String, String> expTypeCodeTranslation = new HashMap<String, String>() {
           {
             put("Q_EXPERIMENTAL_DESIGN", "Patients/Sources");
             put("Q_SAMPLE_EXTRACTION", "Sample Extracts");
@@ -221,7 +220,7 @@ public class UserDBPortletUI extends QBiCPortletUI {
             List<CollaboratorWithResponsibility> collaborators =
                 dbControl.getCollaboratorsOfProject(project);
             // get openbis experiments and type
-            Map<String, String> existingExps = new HashMap<String, String>();
+            Map<String, String> existingExps = new HashMap<>();
             for (Experiment e : openbis.getExperimentsOfProjectByCode(project)) {
               String type = expTypeCodeTranslation.get(e.getType().getCode());
               String id = e.getIdentifier().getIdentifier();
@@ -270,15 +269,15 @@ public class UserDBPortletUI extends QBiCPortletUI {
             if (info.getInvestigator() == null)
               dbControl.removePersonFromProject(id, "PI");
             else
-              dbControl.addOrUpdatePersonToProject(id, personMap.get(info.getInvestigator()).getId(), "PI");
+              dbControl.addOrUpdatePersonToProject(id, info.getInvestigator().getId(), "PI");
             if (info.getContact() == null)
               dbControl.removePersonFromProject(id, "Contact");
             else
-              dbControl.addOrUpdatePersonToProject(id, personMap.get(info.getContact()).getId(), "Contact");
+              dbControl.addOrUpdatePersonToProject(id, info.getContact().getId(), "Contact");
             if (info.getManager() == null)
               dbControl.removePersonFromProject(id, "Manager");
             else
-              dbControl.addOrUpdatePersonToProject(id, personMap.get(info.getManager()).getId(), "Manager");
+              dbControl.addOrUpdatePersonToProject(id, info.getManager().getId(), "Manager");
             projectView.updateChangedInfo(info);
           }
         }
@@ -375,7 +374,7 @@ public class UserDBPortletUI extends QBiCPortletUI {
       @Override
       public void buttonClick(ClickEvent event) {
         if (batchUpload.isValid()) {
-          List<String> registered = new ArrayList<String>();
+          List<String> registered = new ArrayList<>();
           batchUpload.setRegEnabled(false);
           for (Person p : batchUpload.getPeople()) {
             if (dbControl.personExists(p)) {
@@ -572,14 +571,5 @@ public class UserDBPortletUI extends QBiCPortletUI {
   private void commitError(String reason) {
     Styles.notification("There has been an error.", reason, NotificationType.ERROR);
   }
-  //
-  // private String getPortletContextName(VaadinRequest request) {
-  // WrappedPortletSession wrappedPortletSession =
-  // (WrappedPortletSession) request.getWrappedSession();
-  // PortletSession portletSession = wrappedPortletSession.getPortletSession();
-  //
-  // final PortletContext context = portletSession.getPortletContext();
-  // final String portletContextName = context.getPortletContextName();
-  // return portletContextName;
-  // }
+
 }

--- a/src/main/java/life/qbic/portal/portlet/UserDBPortletUI.java
+++ b/src/main/java/life/qbic/portal/portlet/UserDBPortletUI.java
@@ -40,6 +40,7 @@ import life.qbic.userdb.DBManager;
 import life.qbic.userdb.model.Person;
 import life.qbic.userdb.model.Person.PersonBuilder;
 import life.qbic.userdb.model.ProjectInfo;
+import life.qbic.userdb.model.ProjectInfo.ProjectInfoBuilder;
 import life.qbic.userdb.views.AffiliationInput;
 import life.qbic.userdb.views.AffiliationVIPTab;
 import life.qbic.userdb.views.MultiAffiliationTab;
@@ -179,8 +180,10 @@ public class UserDBPortletUI extends QBiCPortletUI {
         desc = desc.replaceAll("\n+", ". ");
         String projectID = p.getIdentifier().getIdentifier();
         String code = p.getCode();
-        if (dbProjects.get(projectID) == null)
-          userProjects.put(projectID, new ProjectInfo(p.getSpace().getCode(), code, desc, "", -1));
+        if (dbProjects.get(projectID) == null) {
+          ProjectInfoBuilder infoBuilder = new ProjectInfoBuilder().createProjectInfo(p.getSpace().getCode(), code, desc, "").withId(-1);
+          userProjects.put(projectID, infoBuilder.getProjectInfo());
+        }
         else {
           ProjectInfo info = dbProjects.get(projectID);
           info.setDescription(desc);

--- a/src/main/java/life/qbic/userdb/DBManager.java
+++ b/src/main/java/life/qbic/userdb/DBManager.java
@@ -38,6 +38,7 @@ import life.qbic.datamodel.persons.RoleAt;
 import life.qbic.userdb.model.Minutes;
 import life.qbic.userdb.model.Person;
 import life.qbic.userdb.model.Person.PersonBuilder;
+import life.qbic.userdb.model.ProjectInfo.ProjectInfoBuilder;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -1550,7 +1551,8 @@ public class DBManager {
           String space = openbisIDSplit[1];
           int id = rs.getInt("project_id");
           String shortName = rs.getString("short_title");
-          res.put(projectID, new life.qbic.userdb.model.ProjectInfo(space, project, "", shortName, id));
+          ProjectInfoBuilder infoBuilder = new ProjectInfoBuilder().createProjectInfo(space, project, "", shortName).withId(id);
+          res.put(projectID, infoBuilder.getProjectInfo());
         }
         // setting person for different role rows
         life.qbic.userdb.model.ProjectInfo info = res.get(projectID);
@@ -1590,7 +1592,8 @@ public class DBManager {
           String space = openbisIDSplit[1];
           int id = rs.getInt("id");
           String shortName = rs.getString("short_title");
-          res.put(projID, new life.qbic.userdb.model.ProjectInfo(space, project, "", shortName, id));
+          ProjectInfoBuilder infoBuilder = new ProjectInfoBuilder().createProjectInfo(space, project, "", shortName).withId(id);
+          res.put(projID, infoBuilder.getProjectInfo());
         } catch (Exception e) {
           logger.error("Could not parse project from openbis identifier " + projID
               + ". It seems this database entry is incorrect. Ignoring project.");

--- a/src/main/java/life/qbic/userdb/DBManager.java
+++ b/src/main/java/life/qbic/userdb/DBManager.java
@@ -795,7 +795,11 @@ public class DBManager {
         String userID = rs.getString("user_id");
         String title = rs.getString("title");
         String email = rs.getString("email");
-        res.put(first + " " + last, new Person(id, title, first, last, email, userID));
+        List<Affiliation> affiliations = new ArrayList<>();
+        for(int affId : getPersonAffiliationIDs(id)) {
+          affiliations.add(getAffiliationWithID(affId));
+        }
+        res.put(first + " " + last, new Person(id, title, first, last, email, userID, affiliations));
       }
     } catch (SQLException e) {
       e.printStackTrace();
@@ -1227,7 +1231,7 @@ public class DBManager {
    * @return
    */
   public List<Person> getPersonWithAffiliations(Integer personID) {
-    List<Person> res = new ArrayList<Person>();
+    List<Person> res = new ArrayList<>();
     String lnk = "person_affiliation";
     String sql =
         "SELECT person.*, affiliation.id, affiliation.organization FROM person, affiliation, " + lnk
@@ -1518,8 +1522,11 @@ public class DBManager {
         String userID = rs.getString("user_id");
         String title = rs.getString("title");
         String email = rs.getString("email");
-        Person person = new Person(personID, title, first, last, email, userID);
-
+        List<Affiliation> affiliations = new ArrayList<>();
+        for(int affId : getPersonAffiliationIDs(personID)) {
+          affiliations.add(getAffiliationWithID(affId));
+        }
+        Person person = new Person(personID, title, first, last, email, userID, affiliations);
 
         if (!res.containsKey(projectID)) {
           // first result row

--- a/src/main/java/life/qbic/userdb/DBManager.java
+++ b/src/main/java/life/qbic/userdb/DBManager.java
@@ -37,6 +37,7 @@ import life.qbic.datamodel.persons.PersonAffiliationConnectionInfo;
 import life.qbic.datamodel.persons.RoleAt;
 import life.qbic.userdb.model.Minutes;
 import life.qbic.userdb.model.Person;
+import life.qbic.userdb.model.Person.PersonBuilder;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -710,7 +711,10 @@ public class DBManager {
         String last = rs.getString("family_name");
         String email = rs.getString("email");
         String phone = rs.getString("phone");
-        existing.add(new Person(username, title, first, last, email, phone, -1, "", ""));
+        PersonBuilder personBuilder = new PersonBuilder();
+        personBuilder.createPerson(title, first, last, email).withUsername(username).withPhoneNumber(phone)
+                .withRoleAtAffiliation(-1, "", "");
+        existing.add(personBuilder.getPerson());
       }
     } catch (SQLException e) {
       e.printStackTrace();
@@ -799,7 +803,9 @@ public class DBManager {
         for(int affId : getPersonAffiliationIDs(id)) {
           affiliations.add(getAffiliationWithID(affId));
         }
-        res.put(first + " " + last, new Person(id, title, first, last, email, userID, affiliations));
+        PersonBuilder personBuilder = new PersonBuilder().createPerson(title, first, last, email)
+                .withId(id).withAffiliations(affiliations).withUsername(userID);
+        res.put(first + " " + last, personBuilder.getPerson());
       }
     } catch (SQLException e) {
       e.printStackTrace();
@@ -969,8 +975,9 @@ public class DBManager {
         String affiliation =
             rs.getString("group_name") + " (" + rs.getString("group_acronym") + ")";
         String role = rs.getString(lnk + ".occupation");
-        res.add(new Person(username, title, first, last, eMail, phone, affiliationID, affiliation,
-            role)); // TODO add every affiliation!
+        PersonBuilder personBuilder = new PersonBuilder().createPerson(title, first, last, eMail)
+            .withId(id).withUsername(username).withPhoneNumber(phone).withRoleAtAffiliation(affiliationID, affiliation, role);
+        res.add(personBuilder.getPerson());
       }
     } catch (SQLException e) {
       e.printStackTrace();
@@ -1254,8 +1261,10 @@ public class DBManager {
         int affiliationID = rs.getInt("affiliation.id");
         String affiliation = rs.getString("organization");
         // set phone number empty due to new table
-        res.add(new Person(username, title, first, last, eMail, "", affiliationID, affiliation,
-            "Member", affiliations));
+        PersonBuilder personBuilder = new PersonBuilder().createPerson(title, first, last, eMail)
+            .withRoleAtAffiliation(affiliationID, affiliation, "Member").withAffiliations(affiliations)
+            .withUsername(username).withPhoneNumber("");
+        res.add(personBuilder.getPerson());
       }
     } catch (SQLException e) {
       e.printStackTrace();
@@ -1317,7 +1326,9 @@ public class DBManager {
         String first = rs.getString("first_name");
         String last = rs.getString("last_name");
         String eMail = rs.getString("email");
-        res = new Person(username, title, first, last, eMail, "", -1, null, null);
+        PersonBuilder personBuilder = new PersonBuilder().createPerson(title, first, last, eMail)
+            .withId(id).withRoleAtAffiliation(-1, null, null).withPhoneNumber("");
+        res = personBuilder.getPerson();
       }
     } catch (SQLException e) {
       e.printStackTrace();
@@ -1388,7 +1399,9 @@ public class DBManager {
           String first = rs.getString("first_name");
           String last = rs.getString("last_name");
           String eMail = rs.getString("email");
-          res.add(new Person(username, title, first, last, eMail, "", -1, "N/A", "N/A"));
+          PersonBuilder personBuilder = new PersonBuilder().createPerson(title, first, last, eMail)
+              .withId(id).withPhoneNumber("").withUsername(username).withRoleAtAffiliation(-1, "N/A", "N/A");
+          res.add(personBuilder.getPerson());
         } else
           res.add(found.get(0));// TODO set all of them!
       }
@@ -1427,7 +1440,9 @@ public class DBManager {
           String last = rs.getString("last_name");
           String eMail = rs.getString("email");
           String phone = "";
-          res.add(new Person(username, title, first, last, eMail, phone, -1, "N/A", "N/A"));
+          PersonBuilder personBuilder = new PersonBuilder().createPerson(title, first, last, eMail)
+              .withId(id).withPhoneNumber(phone).withUsername(username).withRoleAtAffiliation(-1, "N/A", "N/A");
+          res.add(personBuilder.getPerson());
         } else
           res.add(found.get(0));// TODO set all of them!
       }
@@ -1526,7 +1541,9 @@ public class DBManager {
         for(int affId : getPersonAffiliationIDs(personID)) {
           affiliations.add(getAffiliationWithID(affId));
         }
-        Person person = new Person(personID, title, first, last, email, userID, affiliations);
+        PersonBuilder personBuilder = new PersonBuilder().createPerson(title, first, last, email)
+            .withId(personID).withAffiliations(affiliations).withUsername(userID);
+        Person person = personBuilder.getPerson();
 
         if (!res.containsKey(projectID)) {
           // first result row

--- a/src/main/java/life/qbic/userdb/helpers/PersonBatchReader.java
+++ b/src/main/java/life/qbic/userdb/helpers/PersonBatchReader.java
@@ -14,10 +14,9 @@ import java.util.Set;
 
 import javax.xml.bind.JAXBException;
 
+import life.qbic.userdb.model.Person;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-
-import life.qbic.datamodel.persons.Person;
 
 public class PersonBatchReader {
 

--- a/src/main/java/life/qbic/userdb/helpers/PersonBatchReader.java
+++ b/src/main/java/life/qbic/userdb/helpers/PersonBatchReader.java
@@ -15,6 +15,7 @@ import java.util.Set;
 import javax.xml.bind.JAXBException;
 
 import life.qbic.userdb.model.Person;
+import life.qbic.userdb.model.Person.PersonBuilder;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -142,12 +143,13 @@ public class PersonBatchReader {
       String last = row[headerMapping.get("last name")];
       String title = row[headerMapping.get("title")];
       String mail = row[headerMapping.get("email")];
-      Person p = new Person(title, first, last, mail);
+      PersonBuilder personBuilder = new PersonBuilder();
+      personBuilder.createPerson(title, first, last, mail);
       if (headerMapping.get("phone") != null)
-        p.setPhone(row[headerMapping.get("phone")]);
+        personBuilder.withPhoneNumber(row[headerMapping.get("phone")]);
       if (headerMapping.get("username") != null)
-        p.setUsername(row[headerMapping.get("username")]);
-      people.add(p);
+        personBuilder.withUsername(row[headerMapping.get("username")]);
+      people.add(personBuilder.getPerson());
     }
     return true;
   }

--- a/src/main/java/life/qbic/userdb/model/Person.java
+++ b/src/main/java/life/qbic/userdb/model/Person.java
@@ -1,0 +1,208 @@
+package life.qbic.userdb.model;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import life.qbic.datamodel.persons.Affiliation;
+import life.qbic.datamodel.persons.RoleAt;
+
+public class Person {
+  private int id;
+  private String firstName;
+  private String lastName;
+  private String email;
+  private int instituteID;
+  private String username;
+  private String title;
+  private String phone;
+  private Map<Integer, RoleAt> affiliationInfo; // ids and roles
+  private List<Affiliation> affiliations;
+
+  public Person(String username, String title, String first, String last, String eMail,
+      String phone, int affiliationID, String affiliationName, String affRole,
+      List<Affiliation> affiliations) {
+    super();
+    this.username = username;
+    this.title = title;
+    this.firstName = first;
+    this.lastName = last;
+    this.email = eMail;
+    this.phone = phone;
+    this.affiliations = affiliations;
+    affiliationInfo = new HashMap<Integer, RoleAt>();
+    affiliationInfo.put(affiliationID, new RoleAt(affiliationName, affRole));
+  }
+
+  public Person(String username, String title, String first, String last, String eMail,
+      String phone, int affiliationID, String affiliationName, String affRole) {
+    super();
+    this.username = username;
+    this.title = title;
+    this.firstName = first;
+    this.lastName = last;
+    this.email = eMail;
+    this.phone = phone;
+    this.affiliations = new ArrayList<Affiliation>();
+    affiliationInfo = new HashMap<Integer, RoleAt>();
+    affiliationInfo.put(affiliationID, new RoleAt(affiliationName, affRole));
+  }
+
+  public Person(int id, String title, String first, String last, String email, String username) {
+    this.id = id;
+    this.title = title;
+    this.firstName = first;
+    this.lastName = last;
+    this.email = email;
+    this.username = username;
+    affiliationInfo = new HashMap<Integer, RoleAt>();
+  }
+
+  public Person(String title, String first, String last, String email) {
+    this.title = title;
+    this.firstName = first;
+    this.lastName = last;
+    this.email = email;
+    affiliationInfo = new HashMap<Integer, RoleAt>();
+  }
+
+  public Person(String zdvID, String firstName, String lastName, String email, String telephone,
+      int instituteID) {
+    super();
+    this.username = zdvID;
+    this.firstName = firstName;
+    this.lastName = lastName;
+    this.email = email;
+    this.phone = telephone;
+    this.instituteID = instituteID;
+  }
+
+  public String getUsername() {
+    return username;
+  }
+
+  public String getFirstName() {
+    return firstName;
+  }
+
+  public String getLastName() {
+    return lastName;
+  }
+
+  public String getEmail() {
+    return email;
+  }
+
+  public String getTitle() {
+    return title;
+  }
+
+  public String getPhone() {
+    return phone;
+  }
+
+  public int getInstituteID() {
+    return instituteID;
+  }
+
+  public Map<Integer, RoleAt> getAffiliationInfos() {
+    return affiliationInfo;
+  }
+
+  public void addAffiliationInfo(int id, String name, String role) {
+    affiliationInfo.put(id, new RoleAt(name, role));
+  }
+  //
+  // public int getID() {
+  // return id;
+  // }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj)
+      return true;
+    if (obj == null)
+      return false;
+    if (getClass() != obj.getClass())
+      return false;
+    Person other = (Person) obj;
+    if (affiliationInfo == null) {
+      if (other.affiliationInfo != null)
+        return false;
+    } else if (!affiliationInfo.equals(other.affiliationInfo))
+      return false;
+    if (email == null) {
+      if (other.email != null)
+        return false;
+    } else if (!email.equals(other.email))
+      return false;
+    if (firstName == null) {
+      if (other.firstName != null)
+        return false;
+    } else if (!firstName.equals(other.firstName))
+      return false;
+    if (lastName == null) {
+      if (other.lastName != null)
+        return false;
+    } else if (!lastName.equals(other.lastName))
+      return false;
+    if (phone == null) {
+      if (other.phone != null)
+        return false;
+    } else if (!phone.equals(other.phone))
+      return false;
+    if (title == null) {
+      if (other.title != null)
+        return false;
+    } else if (!title.equals(other.title))
+      return false;
+    if (username == null) {
+      if (other.username != null)
+        return false;
+    } else if (!username.equals(other.username))
+      return false;
+    return true;
+  }
+
+  public void setAffiliationID(int affiID) {
+    RoleAt affi = affiliationInfo.get(-1);
+    affiliationInfo.remove(-1);
+    affiliationInfo.put(affiID, affi);
+  }
+
+  public List<Affiliation> getAffiliations() {
+    return affiliations;
+  }
+
+  public int getId() { return id; }
+  public void setPhone(String phone) {
+    this.phone = phone;
+  }
+
+  public void setUsername(String username) {
+    this.username = username;
+  }
+
+  @Override
+  public String toString() {
+    return firstName + " " + lastName + " (" + email + ")";
+  }
+
+  public void setTitle(String title) {
+    this.title = title;
+  }
+
+  /**
+   * returns a random affiliation with its role for this user
+   *
+   * @return
+   */
+  public RoleAt getOneAffiliationWithRole() {
+    Random random = new Random();
+    List<Integer> keys = new ArrayList<Integer>(affiliationInfo.keySet());
+    Integer randomKey = keys.get(random.nextInt(keys.size()));
+    return affiliationInfo.get(randomKey);
+  }
+
+}

--- a/src/main/java/life/qbic/userdb/model/Person.java
+++ b/src/main/java/life/qbic/userdb/model/Person.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Random;
 import life.qbic.datamodel.persons.Affiliation;
 import life.qbic.datamodel.persons.RoleAt;
@@ -13,70 +14,19 @@ public class Person {
   private String firstName;
   private String lastName;
   private String email;
-  private int instituteID;
   private String username;
   private String title;
   private String phone;
   private Map<Integer, RoleAt> affiliationInfo; // ids and roles
   private List<Affiliation> affiliations;
 
-  public Person(String username, String title, String first, String last, String eMail,
-      String phone, int affiliationID, String affiliationName, String affRole,
-      List<Affiliation> affiliations) {
-    super();
-    this.username = username;
-    this.title = title;
-    this.firstName = first;
-    this.lastName = last;
-    this.email = eMail;
-    this.phone = phone;
-    this.affiliations = affiliations;
-    affiliationInfo = new HashMap<Integer, RoleAt>();
-    affiliationInfo.put(affiliationID, new RoleAt(affiliationName, affRole));
-  }
-
-  public Person(String username, String title, String first, String last, String eMail,
-      String phone, int affiliationID, String affiliationName, String affRole) {
-    super();
-    this.username = username;
-    this.title = title;
-    this.firstName = first;
-    this.lastName = last;
-    this.email = eMail;
-    this.phone = phone;
-    this.affiliations = new ArrayList<Affiliation>();
-    affiliationInfo = new HashMap<Integer, RoleAt>();
-    affiliationInfo.put(affiliationID, new RoleAt(affiliationName, affRole));
-  }
-
-  public Person(int id, String title, String first, String last, String email, String username, List<Affiliation> affiliations) {
-    this.id = id;
+  protected Person(String title, String first, String last, String email) {
     this.title = title;
     this.firstName = first;
     this.lastName = last;
     this.email = email;
-    this.username = username;
-    affiliationInfo = new HashMap<Integer, RoleAt>();
-    this.affiliations = affiliations;
-  }
-
-  public Person(String title, String first, String last, String email) {
-    this.title = title;
-    this.firstName = first;
-    this.lastName = last;
-    this.email = email;
-    affiliationInfo = new HashMap<Integer, RoleAt>();
-  }
-
-  public Person(String zdvID, String firstName, String lastName, String email, String telephone,
-      int instituteID) {
-    super();
-    this.username = zdvID;
-    this.firstName = firstName;
-    this.lastName = lastName;
-    this.email = email;
-    this.phone = telephone;
-    this.instituteID = instituteID;
+    affiliationInfo = new HashMap<>();
+    affiliations = new ArrayList<>();
   }
 
   public String getUsername() {
@@ -103,10 +53,6 @@ public class Person {
     return phone;
   }
 
-  public int getInstituteID() {
-    return instituteID;
-  }
-
   public Map<Integer, RoleAt> getAffiliationInfos() {
     return affiliationInfo;
   }
@@ -114,56 +60,57 @@ public class Person {
   public void addAffiliationInfo(int id, String name, String role) {
     affiliationInfo.put(id, new RoleAt(name, role));
   }
-  //
-  // public int getID() {
-  // return id;
-  // }
 
   @Override
-  public boolean equals(Object obj) {
-    if (this == obj)
+  public boolean equals(Object o) {
+    if (this == o) {
       return true;
-    if (obj == null)
+    }
+    if (!(o instanceof Person)) {
       return false;
-    if (getClass() != obj.getClass())
+    }
+
+    Person person = (Person) o;
+
+    if (id != person.id) {
       return false;
-    Person other = (Person) obj;
-    if (affiliationInfo == null) {
-      if (other.affiliationInfo != null)
-        return false;
-    } else if (!affiliationInfo.equals(other.affiliationInfo))
+    }
+    if (!firstName.equals(person.firstName)) {
       return false;
-    if (email == null) {
-      if (other.email != null)
-        return false;
-    } else if (!email.equals(other.email))
+    }
+    if (!lastName.equals(person.lastName)) {
       return false;
-    if (firstName == null) {
-      if (other.firstName != null)
-        return false;
-    } else if (!firstName.equals(other.firstName))
+    }
+    if (!email.equals(person.email)) {
       return false;
-    if (lastName == null) {
-      if (other.lastName != null)
-        return false;
-    } else if (!lastName.equals(other.lastName))
+    }
+    if (!Objects.equals(username, person.username)) {
       return false;
-    if (phone == null) {
-      if (other.phone != null)
-        return false;
-    } else if (!phone.equals(other.phone))
+    }
+    if (!Objects.equals(title, person.title)) {
       return false;
-    if (title == null) {
-      if (other.title != null)
-        return false;
-    } else if (!title.equals(other.title))
+    }
+    if (!Objects.equals(phone, person.phone)) {
       return false;
-    if (username == null) {
-      if (other.username != null)
-        return false;
-    } else if (!username.equals(other.username))
+    }
+    if (!Objects.equals(affiliationInfo, person.affiliationInfo)) {
       return false;
-    return true;
+    }
+    return Objects.equals(affiliations, person.affiliations);
+  }
+
+  @Override
+  public int hashCode() {
+    int result = id;
+    result = 31 * result + firstName.hashCode();
+    result = 31 * result + lastName.hashCode();
+    result = 31 * result + email.hashCode();
+    result = 31 * result + (username != null ? username.hashCode() : 0);
+    result = 31 * result + (title != null ? title.hashCode() : 0);
+    result = 31 * result + (phone != null ? phone.hashCode() : 0);
+    result = 31 * result + (affiliationInfo != null ? affiliationInfo.hashCode() : 0);
+    result = 31 * result + (affiliations != null ? affiliations.hashCode() : 0);
+    return result;
   }
 
   public void setAffiliationID(int affiID) {
@@ -176,22 +123,26 @@ public class Person {
     return affiliations;
   }
 
+  protected void setAffiliations(List<Affiliation> affiliations) {
+    this.affiliations = affiliations;
+  }
+
   public int getId() { return id; }
-  public void setPhone(String phone) {
+
+  protected void setId(int id) {
+    this.id = id;
+  }
+  protected void setPhone(String phone) {
     this.phone = phone;
   }
 
-  public void setUsername(String username) {
+  protected void setUsername(String username) {
     this.username = username;
   }
 
   @Override
   public String toString() {
     return firstName + " " + lastName + " (" + email + ")";
-  }
-
-  public void setTitle(String title) {
-    this.title = title;
   }
 
   /**
@@ -204,6 +155,49 @@ public class Person {
     List<Integer> keys = new ArrayList<Integer>(affiliationInfo.keySet());
     Integer randomKey = keys.get(random.nextInt(keys.size()));
     return affiliationInfo.get(randomKey);
+  }
+
+  public void setTitle(String title) {
+    this.title = title;
+  }
+
+  public static class PersonBuilder {
+
+    private Person person;
+
+    public Person getPerson() {
+      return person;
+    }
+
+    public PersonBuilder createPerson(String title, String first, String last, String email) {
+      person = new Person(title, first, last, email);
+      return this;
+    }
+
+    public PersonBuilder withId(int id) {
+      person.setId(id);
+      return this;
+    }
+
+    public PersonBuilder withPhoneNumber(String phoneNumber) {
+      person.setPhone(phoneNumber);
+      return this;
+    }
+
+    public PersonBuilder withUsername(String username) {
+      person.setUsername(username);
+      return this;
+    }
+
+    public PersonBuilder withAffiliations(List<Affiliation> affiliations) {
+      person.setAffiliations(affiliations);
+      return this;
+    }
+
+    public PersonBuilder withRoleAtAffiliation(int affiliationId, String affiliationName, String role) {
+      person.addAffiliationInfo(affiliationId, affiliationName, role);
+      return this;
+    }
   }
 
 }

--- a/src/main/java/life/qbic/userdb/model/Person.java
+++ b/src/main/java/life/qbic/userdb/model/Person.java
@@ -49,7 +49,7 @@ public class Person {
     affiliationInfo.put(affiliationID, new RoleAt(affiliationName, affRole));
   }
 
-  public Person(int id, String title, String first, String last, String email, String username) {
+  public Person(int id, String title, String first, String last, String email, String username, List<Affiliation> affiliations) {
     this.id = id;
     this.title = title;
     this.firstName = first;
@@ -57,6 +57,7 @@ public class Person {
     this.email = email;
     this.username = username;
     affiliationInfo = new HashMap<Integer, RoleAt>();
+    this.affiliations = affiliations;
   }
 
   public Person(String title, String first, String last, String email) {

--- a/src/main/java/life/qbic/userdb/model/ProjectInfo.java
+++ b/src/main/java/life/qbic/userdb/model/ProjectInfo.java
@@ -1,5 +1,6 @@
 package life.qbic.userdb.model;
 
+import java.util.Objects;
 import life.qbic.userdb.model.Person.PersonBuilder;
 
 public class ProjectInfo {
@@ -68,6 +69,54 @@ public class ProjectInfo {
     res += "Ctct: " + contact + ", ";
     res += "Mngr: " + manager;
     return res;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof ProjectInfo)) {
+      return false;
+    }
+
+    ProjectInfo that = (ProjectInfo) o;
+
+    if (projectID != that.projectID) {
+      return false;
+    }
+    if (!Objects.equals(description, that.description)) {
+      return false;
+    }
+    if (!Objects.equals(secondaryName, that.secondaryName)) {
+      return false;
+    }
+    if (!Objects.equals(investigator, that.investigator)) {
+      return false;
+    }
+    if (!Objects.equals(contact, that.contact)) {
+      return false;
+    }
+    if (!Objects.equals(manager, that.manager)) {
+      return false;
+    }
+    if (!Objects.equals(space, that.space)) {
+      return false;
+    }
+    return Objects.equals(projectCode, that.projectCode);
+  }
+
+  @Override
+  public int hashCode() {
+    int result = description != null ? description.hashCode() : 0;
+    result = 31 * result + (secondaryName != null ? secondaryName.hashCode() : 0);
+    result = 31 * result + (investigator != null ? investigator.hashCode() : 0);
+    result = 31 * result + (contact != null ? contact.hashCode() : 0);
+    result = 31 * result + (manager != null ? manager.hashCode() : 0);
+    result = 31 * result + (space != null ? space.hashCode() : 0);
+    result = 31 * result + (projectCode != null ? projectCode.hashCode() : 0);
+    result = 31 * result + projectID;
+    return result;
   }
 
   public String getProjectCode() {

--- a/src/main/java/life/qbic/userdb/model/ProjectInfo.java
+++ b/src/main/java/life/qbic/userdb/model/ProjectInfo.java
@@ -1,0 +1,102 @@
+package life.qbic.userdb.model;
+
+public class ProjectInfo {
+
+  private String description;
+  private String secondaryName;
+  private Person investigator;
+  private Person contact;
+  private Person manager;
+  private boolean isPilot;
+  private String space;
+  private String projectCode;
+  private int projectID;
+
+  public ProjectInfo(String space, String code, String description, String secondaryName,
+      boolean isPilot, Person investigator, Person contact, Person manager) {
+    this.space = space;
+    this.projectCode = code;
+    this.description = description;
+    this.secondaryName = secondaryName;
+    this.isPilot = isPilot;
+    this.investigator = investigator;
+    this.contact = contact;
+    this.manager = manager;
+  }
+
+  public ProjectInfo(String space, String code, String description, String secondaryName, int id) {
+    this.space = space;
+    this.projectCode = code;
+    this.description = description;
+    this.secondaryName = secondaryName;
+    this.projectID = id;
+    this.isPilot = false;
+  }
+
+  public boolean isPilot() {
+    return isPilot;
+  }
+
+  public String getDescription() {
+    return description;
+  }
+
+  public String getSecondaryName() {
+    return secondaryName;
+  }
+
+  public void setDescription(String description) {
+    this.description = description;
+  }
+
+  public void setSecondaryName(String secondaryName) {
+    this.secondaryName = secondaryName;
+  }
+
+  public Person getInvestigator() {
+    return investigator;
+  }
+
+  public Person getContact() {
+    return contact;
+  }
+
+  public Person getManager() {
+    return manager;
+  }
+
+
+  public void setManager(Person manager) {
+    this.manager = manager;
+  }
+
+  public void setContact(Person contact) {
+    this.contact = contact;
+  }
+
+  public void setInvestigator(Person investigator) {
+    this.investigator = investigator;
+  }
+
+  @Override
+  public String toString() {
+    String res = projectCode + " (" + secondaryName + ")\n";
+    res += "PI: " + investigator + ", ";
+    res += "Ctct: " + contact + ", ";
+    res += "Mngr: " + manager;
+    return res;
+  }
+
+  public String getProjectCode() {
+    return projectCode;
+  }
+
+  public String getSpace() {
+    return space;
+  }
+
+  public int getProjectID() {
+    return projectID;
+  }
+}
+

--- a/src/main/java/life/qbic/userdb/model/ProjectInfo.java
+++ b/src/main/java/life/qbic/userdb/model/ProjectInfo.java
@@ -1,5 +1,7 @@
 package life.qbic.userdb.model;
 
+import life.qbic.userdb.model.Person.PersonBuilder;
+
 public class ProjectInfo {
 
   private String description;
@@ -7,34 +9,15 @@ public class ProjectInfo {
   private Person investigator;
   private Person contact;
   private Person manager;
-  private boolean isPilot;
   private String space;
   private String projectCode;
   private int projectID;
 
-  public ProjectInfo(String space, String code, String description, String secondaryName,
-      boolean isPilot, Person investigator, Person contact, Person manager) {
+  protected ProjectInfo(String space, String code, String description, String secondaryName) {
     this.space = space;
     this.projectCode = code;
     this.description = description;
     this.secondaryName = secondaryName;
-    this.isPilot = isPilot;
-    this.investigator = investigator;
-    this.contact = contact;
-    this.manager = manager;
-  }
-
-  public ProjectInfo(String space, String code, String description, String secondaryName, int id) {
-    this.space = space;
-    this.projectCode = code;
-    this.description = description;
-    this.secondaryName = secondaryName;
-    this.projectID = id;
-    this.isPilot = false;
-  }
-
-  public boolean isPilot() {
-    return isPilot;
   }
 
   public String getDescription() {
@@ -98,5 +81,36 @@ public class ProjectInfo {
   public int getProjectID() {
     return projectID;
   }
+
+  public static class ProjectInfoBuilder {
+
+    private ProjectInfo info;
+
+    public ProjectInfo getProjectInfo() {
+      return info;
+    }
+
+    public ProjectInfoBuilder createProjectInfo(String space, String code, String description, String secondaryName) {
+      info = new ProjectInfo(space, code, description, secondaryName);
+      return this;
+    }
+
+    public ProjectInfoBuilder withPersons(Person investigator, Person contact, Person manager) {
+      info.setInvestigator(investigator);
+      info.setContact(contact);
+      info.setManager(manager);
+      return this;
+    }
+
+    public ProjectInfoBuilder withId(int id) {
+      info.setId(id);
+      return this;
+    }
 }
+
+  private void setId(int id) {
+    this.projectID = id;
+  }
+
+  }
 

--- a/src/main/java/life/qbic/userdb/views/MultiAffiliationTab.java
+++ b/src/main/java/life/qbic/userdb/views/MultiAffiliationTab.java
@@ -27,9 +27,9 @@ import com.vaadin.ui.Table;
 import com.vaadin.ui.VerticalLayout;
 import com.vaadin.ui.Button.ClickEvent;
 import com.vaadin.ui.themes.ValoTheme;
-import life.qbic.datamodel.persons.Person;
 import life.qbic.datamodel.persons.PersonAffiliationConnectionInfo;
 import life.qbic.datamodel.persons.RoleAt;
+import life.qbic.userdb.model.Person;
 
 public class MultiAffiliationTab extends VerticalLayout {
 

--- a/src/main/java/life/qbic/userdb/views/PersonBatchUpload.java
+++ b/src/main/java/life/qbic/userdb/views/PersonBatchUpload.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import life.qbic.userdb.model.Person;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -43,7 +44,6 @@ import com.vaadin.ui.Upload.FinishedEvent;
 import com.vaadin.ui.Upload.FinishedListener;
 import com.vaadin.ui.themes.ValoTheme;
 
-import life.qbic.datamodel.persons.Person;
 import life.qbic.portal.Styles;
 import life.qbic.portal.Styles.NotificationType;
 import life.qbic.portal.portlet.UserDBPortletUI;

--- a/src/main/java/life/qbic/userdb/views/PersonInput.java
+++ b/src/main/java/life/qbic/userdb/views/PersonInput.java
@@ -36,6 +36,7 @@ import life.qbic.datamodel.persons.Affiliation;
 import life.qbic.portal.Styles;
 import life.qbic.userdb.helpers.RegExHelper;
 import life.qbic.userdb.model.Person;
+import life.qbic.userdb.model.Person.PersonBuilder;
 
 public class PersonInput extends HorizontalLayout {
 
@@ -176,8 +177,11 @@ public class PersonInput extends HorizontalLayout {
     int affiID = -1;
     if (affiliationMap.containsKey(affi))
       affiID = affiliationMap.get(affi);
-    return new Person(userName.getValue(), ttl, first.getValue(), last.getValue(), eMail.getValue(),
-        phone.getValue(), affiID, affi, affRole);
+    PersonBuilder builder = new PersonBuilder().createPerson(ttl, first.getValue(), last.getValue(), eMail.getValue())
+        .withUsername(userName.getValue())
+        .withPhoneNumber(phone.getValue())
+        .withRoleAtAffiliation(affiID, affi, affRole);
+    return builder.getPerson();
   }
 
   public boolean hasNewAffiliation() {

--- a/src/main/java/life/qbic/userdb/views/PersonInput.java
+++ b/src/main/java/life/qbic/userdb/views/PersonInput.java
@@ -33,9 +33,9 @@ import com.vaadin.ui.themes.ValoTheme;
 import java.util.List;
 import java.util.Map;
 import life.qbic.datamodel.persons.Affiliation;
-import life.qbic.datamodel.persons.Person;
 import life.qbic.portal.Styles;
 import life.qbic.userdb.helpers.RegExHelper;
+import life.qbic.userdb.model.Person;
 
 public class PersonInput extends HorizontalLayout {
 

--- a/src/main/java/life/qbic/userdb/views/ProjectView.java
+++ b/src/main/java/life/qbic/userdb/views/ProjectView.java
@@ -39,11 +39,11 @@ import java.util.Map;
 import java.util.Objects;
 import life.qbic.datamodel.persons.Affiliation;
 import life.qbic.datamodel.persons.CollaboratorWithResponsibility;
-import life.qbic.datamodel.persons.Person;
-import life.qbic.datamodel.projects.ProjectInfo;
 import life.qbic.portal.Styles;
 import life.qbic.portal.portlet.ProjectFilterDecorator;
 import life.qbic.portal.portlet.ProjectFilterGenerator;
+import life.qbic.userdb.model.Person;
+import life.qbic.userdb.model.ProjectInfo;
 import life.qbic.utils.TimeUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
@@ -59,7 +59,7 @@ public class ProjectView extends VerticalLayout {
   private FileDownloader tableDL;
 
   private Map<String, ProjectInfo> projectMap;
-  private Map<String, Integer> personMap;
+  private Map<String, Person> personMap;
 
   private CheckBox showIncomplete;
 
@@ -78,7 +78,7 @@ public class ProjectView extends VerticalLayout {
 
   private VerticalLayout projectInfoLayout;
 
-  public ProjectView(Map<String, ProjectInfo> projectMap, Map<String, Integer> personMap) {
+  public ProjectView(Map<String, ProjectInfo> projectMap, Map<String, Person> personMap) {
     setSpacing(true);
     setMargin(true);
 
@@ -161,7 +161,7 @@ public class ProjectView extends VerticalLayout {
     projectInfoLayout.setSpacing(true);
     addComponent(projectInfoLayout);
   }
-  
+
   public void initProjectTable(boolean showIncompleteOnly) {
     projectTable.removeAllItems();
     for (String code : projectMap.keySet()) {
@@ -169,9 +169,9 @@ public class ProjectView extends VerticalLayout {
       List<Object> row = new ArrayList<Object>();
 
       String secName = p.getSecondaryName();
-      String inv = p.getInvestigator();
-      String mang = p.getManager();
-      String cont = p.getContact();
+      String inv = getFullName(p.getInvestigator());
+      String mang = getFullName(p.getManager());
+      String cont = getFullName(p.getContact());
 
       row.add(code);
       row.add(secName);
@@ -205,16 +205,10 @@ public class ProjectView extends VerticalLayout {
   /**
    * Creates a tab separated values file of the available project information
    * 
-   * @param manager
-   * @param contact
+   * @param subProject
    * @param PI
-   * 
-   * @param managerName
-   * @param contactName
-   * @param invName
-   * @param space
-   * @param secondaryName
-   * @param string
+   * @param contact
+   * @param manager
    * 
    * @return
    * @throws FileNotFoundException
@@ -273,14 +267,9 @@ public class ProjectView extends VerticalLayout {
       String name = proj.getSecondaryName();
       name = name == null ? "" : name;
       String space = proj.getSpace();
-      String inv = proj.getInvestigator();
-      inv = inv == null ? "" : inv;
-      String cont = proj.getContact();
-      cont = cont == null ? "" : cont;
-      String mang = proj.getManager();
-      mang = mang == null ? "" : mang;
       String row = replaceSpecialSymbols(
-          String.join("\t", Arrays.asList(code, name, space, inv, cont, mang)));
+          String.join("\t", Arrays.asList(code, name, space, getFullName(proj.getInvestigator()),
+              getFullName(proj.getContact()), getFullName(proj.getManager()))));
       builder.append(row + "\n");
     }
     return builder.toString();
@@ -313,6 +302,7 @@ public class ProjectView extends VerticalLayout {
   }
 
   private String getFullName(Person person) {
+    if(person==null) return "";
     return person.getFirstName() + " " + person.getLastName();
   }
 
@@ -378,41 +368,35 @@ public class ProjectView extends VerticalLayout {
     String oldName = p.getSecondaryName();
     String newName = altName.getValue();
 
-    String oldPI = p.getInvestigator();
-    Object newPI = investigatorBox.getValue();
-    boolean updatePI = oldPI != newPI;
-    if (oldPI != null)
-      updatePI = !oldPI.equals(newPI);
+    String oldPIName = getFullName(p.getInvestigator());
+    Object newPIName = investigatorBox.getValue();
+    boolean updatePI = !oldPIName.equals(newPIName);
 
-    String oldContact = p.getContact();
-    Object newContact = contactBox.getValue();
-    boolean updateContact = oldContact != newContact;
-    if (oldContact != null)
-      updateContact = !oldContact.equals(newContact);
+    String oldContactName = getFullName(p.getContact());
+    Object newContactName = contactBox.getValue();
+    boolean updateContact = !oldContactName.equals(newContactName);
 
-    String oldManager = p.getManager();
-    Object newManager = managerBox.getValue();
-    boolean updateManager = oldManager != newManager;
-    if (oldManager != null)
-      updateManager = !oldManager.equals(newManager);
+    String oldManagerName = getFullName(p.getManager());
+    Object newManagerName = managerBox.getValue();
+    boolean updateManager = !oldManagerName.equals(newManagerName);
 
     boolean update = !oldName.equals(newName) || updatePI || updateContact || updateManager;
     if (update) {
       // initProjectInfos(projectMap.values());
       ProjectInfo newInfo =
           new ProjectInfo(p.getSpace(), code, p.getDescription(), newName, p.getProjectID());
-      if (newPI != null)
-        newInfo.setInvestigator(newPI.toString());
+      if (newPIName != null)
+        newInfo.setInvestigator(personMap.get(newPIName.toString()));
       else
-        newInfo.setInvestigator("");
-      if (newContact != null)
-        newInfo.setContact(newContact.toString());
+        newInfo.setInvestigator(null);
+      if (newContactName != null)
+        newInfo.setContact(personMap.get(newContactName.toString()));
       else
-        newInfo.setContact("");
-      if (newManager != null)
-        newInfo.setManager(newManager.toString());
+        newInfo.setContact(null);
+      if (newManagerName != null)
+        newInfo.setManager(personMap.get(newManagerName.toString()));
       else
-        newInfo.setManager("");
+        newInfo.setManager(null);
       return newInfo;
     } else {
       logger.debug("No changes to project info detected");

--- a/src/main/java/life/qbic/userdb/views/ProjectView.java
+++ b/src/main/java/life/qbic/userdb/views/ProjectView.java
@@ -283,7 +283,7 @@ public class ProjectView extends VerticalLayout {
   }
 
   private void addPersonInfos(List<String> data, Person p) {
-    if (p != null) {
+    if (p != null && !p.getAffiliations().isEmpty()) {
       data.add(getFullName(p));
       data.add(p.getEmail());
       Affiliation affi = p.getAffiliations().get(0);
@@ -503,9 +503,10 @@ public class ProjectView extends VerticalLayout {
       projectInfoLayout.setCaption(projectMap.get(item).getProjectCode());
       logger.info("Selected project: " + projectMap.get(item));
       altName.setValue(secondaryName);
-      investigatorBox.setValue(projectMap.get(item).getInvestigator());
-      contactBox.setValue(projectMap.get(item).getContact());
-      managerBox.setValue(projectMap.get(item).getManager());
+
+      investigatorBox.setValue(getStringOrNullElement(getFullName(projectMap.get(item).getInvestigator())));
+      contactBox.setValue(getStringOrNullElement(getFullName(projectMap.get(item).getContact())));
+      managerBox.setValue(getStringOrNullElement(getFullName(projectMap.get(item).getManager())));
       try {
         armSingleProjectDownloadButton(item, PI, contact, manager);
         downloadProjectInfo.setVisible(true);
@@ -517,6 +518,11 @@ public class ProjectView extends VerticalLayout {
       }
       projectInfoLayout.setVisible(true);
     }
+  }
+
+  private String getStringOrNullElement(String input) {
+    if(input.isEmpty()) return null;
+    return input;
   }
 
 }

--- a/src/main/java/life/qbic/userdb/views/ProjectView.java
+++ b/src/main/java/life/qbic/userdb/views/ProjectView.java
@@ -44,6 +44,7 @@ import life.qbic.portal.portlet.ProjectFilterDecorator;
 import life.qbic.portal.portlet.ProjectFilterGenerator;
 import life.qbic.userdb.model.Person;
 import life.qbic.userdb.model.ProjectInfo;
+import life.qbic.userdb.model.ProjectInfo.ProjectInfoBuilder;
 import life.qbic.utils.TimeUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
@@ -383,8 +384,8 @@ public class ProjectView extends VerticalLayout {
     boolean update = !oldName.equals(newName) || updatePI || updateContact || updateManager;
     if (update) {
       // initProjectInfos(projectMap.values());
-      ProjectInfo newInfo =
-          new ProjectInfo(p.getSpace(), code, p.getDescription(), newName, p.getProjectID());
+      ProjectInfoBuilder infoBuilder = new ProjectInfoBuilder().createProjectInfo(p.getSpace(), code, p.getDescription(), newName).withId(p.getProjectID());
+      ProjectInfo newInfo = infoBuilder.getProjectInfo();
       if (newPIName != null)
         newInfo.setInvestigator(personMap.get(newPIName.toString()));
       else

--- a/src/main/java/life/qbic/userdb/views/SearchView.java
+++ b/src/main/java/life/qbic/userdb/views/SearchView.java
@@ -30,7 +30,7 @@ import com.vaadin.ui.VerticalLayout;
 import com.vaadin.ui.themes.ValoTheme;
 
 import life.qbic.datamodel.persons.Affiliation;
-import life.qbic.datamodel.persons.Person;
+import life.qbic.userdb.model.Person;
 
 public class SearchView extends VerticalLayout {
 

--- a/src/main/java/life/qbic/userdb/views/TableOverview.java
+++ b/src/main/java/life/qbic/userdb/views/TableOverview.java
@@ -26,8 +26,8 @@ import com.vaadin.ui.VerticalLayout;
 import com.vaadin.ui.themes.ValoTheme;
 
 import life.qbic.datamodel.persons.Affiliation;
-import life.qbic.datamodel.persons.Person;
 import life.qbic.datamodel.persons.RoleAt;
+import life.qbic.userdb.model.Person;
 
 public class TableOverview extends VerticalLayout {
 


### PR DESCRIPTION
- Fixes error where two people in the database with the same name would sometimes lead to nullpointer exceptions when the wrong person is fetched.
- The fix includes fetching whole objects, including the unique id
- Some removal of unnecessary code and changes to code clarity